### PR TITLE
test 10_webgl-browser.md

### DIFF
--- a/docs/v2/10_webgl-browser.md
+++ b/docs/v2/10_webgl-browser.md
@@ -35,7 +35,7 @@ Here's NFTPixels to walk you through building out your project to WebGL
 int networkId = Web3GL.Network();
 ```
 
-### Block number {#block-number}
+### Block Number {#block-number}
 
 Get the current latest block number
 


### PR DESCRIPTION
- fixed capitalization on "Block Numbers"

closes: [#125](https://github.com/ChainSafe/devrel/issues/125) 