### PR TITLE
Add explanations to code snippets for gaming docs sections 4-6

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -212,3 +212,7 @@ customizations
 changelogs
 Ethereum's
 wei
+CRO
+Chain721
+tokenIds
+URIs

--- a/docs/v2/4_erc20-interactions.md
+++ b/docs/v2/4_erc20-interactions.md
@@ -9,7 +9,7 @@ sidebar_label: ERC-20 Interactions
 
 :::info
 
-A standard interface for native & custom fungible tokens.
+A standard interface for native & custom fungible tokens. A native token is specifically designed to be used as a currency, medium of exchange, or gas token within that blockchain (e.g. ETH, MATIC, BNB, CRO). A custom token, on the other hand, is built on an existing blockchain platform, such as Ethereum, using a smart contract standard like the ERC-20 fungible token standard.
 
 :::
 
@@ -20,7 +20,7 @@ Here's a video explanation to help you better understand our new ERC-20 prefabs:
 
 ### Call Custom Blockchain Tokens {#call-custom-blockchain-tokens}
 
-Connect to any EVM-compatible blockchain by providing an RPC. All methods have an optional field to add an RPC URL. This returns a custom ERC-20 token's balance. If you'd like to get the balance of a native ERC-20 token you can use the second code snippet below.
+Connect to any EVM-compatible blockchain by providing an RPC. All methods have an optional field to add an RPC URL. This returns a custom ERC-20 token's balance. If you'd like to get the balance of a native ERC-20 token, see [Balance of Native Token](#balance-of-native).
 
 ```csharp
 using Web3Unity.Scripts.Library.Ethers.Providers;
@@ -48,11 +48,11 @@ public class ERC20CustomTokenBalance : MonoBehaviour
 
 :::info
 
-In the following code snippet examples, we will use [Circle's USDC](https://developers.circle.com/developer/docs/usdc-on-testnet) ERC-20 token contract as found on the Goerli testnet for demonstration purposes.
+In the following code snippet examples, we will use [Circle's USDC](https://developers.circle.com/developer/docs/usdc-on-testnet) ERC-20 token contract as found on the Goerli testnet for demonstration purposes. We use "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2" as the example address to fetch from.
 
 :::
 
-### Balance Of {#balance-of}
+### Balance Of Custom Token {#balance-of-custom}
 
 Returns the balance of an ERC-20 token for a specific Ethereum account (e.g. "USDC").
 
@@ -73,8 +73,9 @@ public class ERC20BalanceOfExample : MonoBehaviour
     }
 }
 ```
+### Balance Of Native Token {#balance-of-native}
 
-If you need the chain's native token balance you can fetch it using the native balance of prefab:
+Returns the balance of a native token for a specific Ethereum account (e.g. "ETH").
 
 ```csharp
 using UnityEngine;
@@ -165,7 +166,7 @@ public class ERC20TotalSupplyExample : MonoBehaviour
 {
     async void Start()
     {
-        string contract = "0x3E0C0447e47d49195fbE329265E330643eB42e6f";
+        string contract = "0x07865c6E87B9F70255377e024ace6630C1Eaa37F";
         BigInteger totalSupply = await ERC20.TotalSupply(contract);
         print(totalSupply);
     }

--- a/docs/v2/5_erc721-interactions.md
+++ b/docs/v2/5_erc721-interactions.md
@@ -9,7 +9,7 @@ sidebar_label: ERC-721 Interactions
 
 :::info
 
-A standard interface for non-fungible tokens.
+A standard interface for non-fungible tokens, or NFTs.
 
 :::
 
@@ -18,9 +18,15 @@ A standard interface for non-fungible tokens.
 Here's a video explanation to help you better understand our new ERC-721 prefabs:
 <iframe width="800" height="450" src="https://www.youtube.com/embed/lfPCldSqaq4?list=PLPn3rQCo3XrP6kFaurgMfMQBsyppYBhqW" title="Interacting With ERC-721 Prefabs On web3.unity v2" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
+:::info
+
+In the following code snippet examples, we will use an ERC-721 token contract, as found on the Goerli testnet, called "Chain721 (C721)" for demonstration purposes. We use "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2" as the example address to fetch from.
+
+:::
+
 ### Balance Of {#balance-of}
 
-Counts all NFTs assigned to an owner
+Fetches and counts the balance of a specific ERC-721 NFT token for a specific Ethereum account.
 
 ```csharp
 using System.Numerics;
@@ -42,7 +48,7 @@ public class ERC721BalanceOfExample : MonoBehaviour
 
 ### Owner Of {#owner-of}
 
-Find the owner of an NFT
+Fetches the owner of a specific ERC-721 NFT token for a specific Ethereum account.
 
 ```csharp
 using Web3Unity.Scripts.Library.ETHEREUEM.EIP;
@@ -52,8 +58,8 @@ public class ERC721OwnerOfExample : MonoBehaviour
 {
     async void Start()
     {
-        string contract = "0x06dc21f89f01409e7ed0e4c80eae1430962ae52c";
-        string tokenId = "0x01559ae4021a565d5cc4740f1cefa95de8c1fb193949ecd32c337b03047da501";
+        string contract = "0x9123541E259125657F03D7AD2A7D1a8Ec79375BA";
+        string tokenId = "1";
         string ownerOf = await ERC721.OwnerOf(contract, tokenId);
         print(ownerOf);
     }
@@ -61,6 +67,8 @@ public class ERC721OwnerOfExample : MonoBehaviour
 ```
 
 ### Owner Of Batch {#owner-of-batch}
+
+Returns a list of addresses representing the owners of the specified `tokenIds` passed in the `tokenIds` array.
 
 ```csharp
 using System.Collections.Generic;
@@ -86,6 +94,8 @@ public class ERC721OwnerOfBatchExample : MonoBehaviour
 
 ### URI {#uri"}
 
+Returns the Uniform Resource Identifier (URI) associated with the specified ERC-721 NFT token. The URI may contain metadata about the NFT, such as its name, description, and image.
+
 ```csharp
 using Web3Unity.Scripts.Library.ETHEREUEM.EIP;
 using UnityEngine;
@@ -94,8 +104,8 @@ public class ERC721URIExample : MonoBehaviour
 {
     async void Start()
     {
-        string contract = "0x06dc21f89f01409e7ed0e4c80eae1430962ae52c";
-        string tokenId = "0x01559ae4021a565d5cc4740f1cefa95de8c1fb193949ecd32c337b03047da501";
+        string contract = "0x9123541E259125657F03D7AD2A7D1a8Ec79375BA";
+        string tokenId = "1";
 
         string uri = await ERC721.URI(contract, tokenId);
         print(uri);
@@ -104,6 +114,8 @@ public class ERC721URIExample : MonoBehaviour
 ```
 
 ### All 721's {#all-721s"}
+
+Searches through a specified number of `tokenIds` for each NFT contract in the `nftContracts` array, and logs the tokenIds and URIs of the tokens owned by the account.
 
 ```csharp
 using UnityEngine;

--- a/docs/v2/6_erc1155-interactions.md
+++ b/docs/v2/6_erc1155-interactions.md
@@ -20,6 +20,11 @@ sidebar_label: ERC-1155 Interactions
 Here's a video explanation to help you better understand the new prefabs in web3.unity's latest release:
 <iframe width="800" height="450" src="https://www.youtube.com/embed/35GdxYaEjlM?list=PLPn3rQCo3XrP6kFaurgMfMQBsyppYBhqW" title="Interacting With ERC-1155 Prefabs On web3.unity v2" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
+:::info
+
+ In the following code snippet examples, we will use two separate ERC-1155 NFT token contracts for demonstration purposes. Both can be found on the Goerli testnet, with one collection titled "ERC1155", and the other titled "beautiful collection - 1155".
+:::
+
 ### Balance Of {#balance-of}
 
 Returns the balance of an ERC-1155 token for a specific Ethereum account.

--- a/docs/v2/6_erc1155-interactions.md
+++ b/docs/v2/6_erc1155-interactions.md
@@ -22,6 +22,8 @@ Here's a video explanation to help you better understand the new prefabs in web3
 
 ### Balance Of {#balance-of}
 
+Returns the balance of an ERC-1155 token for a specific Ethereum account.
+
 ```csharp
 using System.Numerics;
 using Web3Unity.Scripts.Library.ETHEREUEM.EIP;
@@ -33,7 +35,7 @@ public class ERC1155BalanceOfExample : MonoBehaviour
     {
         string contract = "0x2c1867bc3026178a47a677513746dcc6822a137a";
         string account = "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2";
-        string tokenId = "0x01559ae4021aee70424836ca173b6a4e647287d15cee8ac42d8c2d8d128927e5";
+        string tokenId = "603563865116164662793910721003851746789058690951049436470293668557855349050";
 
         BigInteger balanceOf = await ERC1155.BalanceOf(contract, account, tokenId);
         print(balanceOf);
@@ -43,11 +45,11 @@ public class ERC1155BalanceOfExample : MonoBehaviour
 
 ### Balance Of Batch {#balance-of-batch}
 
-Balance of batch will get the balance of a list of accounts and token ID's. For example:
+Get the balances of multiple `tokenIDs` owned by multiple accounts for a specific ERC-1155 contract on the Ethereum blockchain. For example:
 
-Get the balance of account `0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2` with token id `1` and
+Get the balance of account `0x990aef1085b2f6480a94bba53cbc03215d321e25` with token id `1` and
 
-balance of account `0xE51995Cdb3b1c109E0e6E67ab5aB31CDdBB83E4a` with token id `2`
+balance of account `0x9cd14e32E3B1AAf35D61EBD9066Ef8e3B06b23ad` with token id `2`
 
 ```csharp
 using System.Numerics;
@@ -60,7 +62,7 @@ public class ERC1155BalanceOfBatchExample : MonoBehaviour
     async void Start()
     {
         string contract = "0xdc4aff511e1b94677142a43df90f948f9ae181dd";
-        string[] accounts = { "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2", "0xE51995Cdb3b1c109E0e6E67ab5aB31CDdBB83E4a" };
+        string[] accounts = { "0x990aef1085b2f6480a94bba53cbc03215d321e25", "0x9cd14e32E3B1AAf35D61EBD9066Ef8e3B06b23ad" };
         string[] tokenIds = { "1", "2" };
 
         List<BigInteger> batchBalances = await ERC1155.BalanceOfBatch(contract, accounts, tokenIds);
@@ -74,7 +76,7 @@ public class ERC1155BalanceOfBatchExample : MonoBehaviour
 
 ### URI {#uri}
 
-Returns metadata about the token.
+Returns the Uniform Resource Identifier (URI) associated with the specified ERC-1155 NFT token. The URI may contain metadata about the NFT, such as its name, description, and image.
 
 ```csharp
 using Web3Unity.Scripts.Library.ETHEREUEM.EIP;
@@ -85,7 +87,7 @@ public class ERC1155URIExample : MonoBehaviour
     async void Start()
     {
         string contract = "0x2c1867BC3026178A47a677513746DCc6822A137A";
-        string tokenId = "0x01559ae4021aee70424836ca173b6a4e647287d15cee8ac42d8c2d8d128927e5";
+        string tokenId = "603563865116164662793910721003851746789058690951049436470293668557855349050";
         string uri = await ERC1155.URI(contract, tokenId);
         print(uri);
     }
@@ -93,6 +95,8 @@ public class ERC1155URIExample : MonoBehaviour
 ```
 
 ### All 1155's {#all-1155s"}
+
+Retrieves the balance and URI of the specified token for each contract in the `nftContracts` array.
 
 ```csharp
 using System.Numerics;


### PR DESCRIPTION
* added code explanations for sections 4-6 (ERC-20, 721, 1155 interactions).
* changed contract addresses referenced on Goerli testnet for consistency in all NFT examples
* added info disclaimer before each code snippet section clarify for demonstration purposes

closes: [#142](https://github.com/ChainSafe/devrel/issues/142)