### PR TITLE
fix dead link in section 7 (In-game NFT minting)

### DIFF
--- a/docs/v2/10_webgl-browser.md
+++ b/docs/v2/10_webgl-browser.md
@@ -39,7 +39,7 @@ int networkId = Web3GL.Network();
 
 ### Block Number {#block-number}
 
-Get the current (i.e. latest) block number from a specified node using the `JsonRpcProvider` variable.
+Get the current (i.e. latest) block number.
 
 ```csharp
 using Web3Unity.Scripts.Library.Ethers.Providers;
@@ -98,7 +98,7 @@ public class WebGLGetGasLimit : MonoBehaviour
 
 ### Transaction Status {#transaction-status}
 
-Allows the user to send a transaction to a specified Ethereum account using the `Web3GL` library. The transaction includes the recipient address, `value` (in wei), `gasLimit`, and `gasPrice`. Once the transaction is sent, the script checks the status of the transaction by calling the `GetTransactionReceipt` function. If the transaction was successful, the script logs a message indicating success, otherwise it logs a message indicating failure. If an exception is thrown during the transaction process, the script logs the exception.
+The `GetTransactionReceipt` method can be used to await the status of a submitted transaction.
 
 ```csharp
 using Nethereum.Hex.HexTypes;

--- a/docs/v2/10_webgl-browser.md
+++ b/docs/v2/10_webgl-browser.md
@@ -57,7 +57,7 @@ public class WebGLGetBlockNumber : MonoBehaviour
 
 ### Gas Price {#gas-price}
 
-Get the **current gas price** for a transaction based on chain / network and RPC. Used to estimate the transaction fees required to execute certain actions on the Ethereum blockchain within the game, such as transfering assets between players or minting new in-game NFTs. For more on gas prices, see [What is gas?](https://ethereum.org/en/developers/docs/gas/#what-is-gas)
+Get the **current gas price** for a transaction based on chain / network and RPC. Used to estimate the transaction fees required to execute certain actions on the Ethereum blockchain within the game, such as transferring assets between players or minting new in-game NFTs. For more on gas prices, see [What is gas?](https://ethereum.org/en/developers/docs/gas/#what-is-gas)
 
 ```csharp
 using Web3Unity.Scripts.Library.Ethers.Providers;
@@ -75,7 +75,7 @@ public class WebGLGetGasPrice : MonoBehaviour
 
 ### Gas Limit {#gas-limit}
 
-Get the **current gas limit** for a transaction based on chain / network and RPC. Used in combination with the gas price of Ethereum to estimate the transaction fees required to execute certain actions on the Ethereum blockchain within the game, such as transfering assets between players or minting new in-game NFTs. For more on gas limits, see [What is gas limit?](https://ethereum.org/en/developers/docs/gas/#what-is-gas-limit)
+Get the **current gas limit** for a transaction based on chain / network and RPC. Used in combination with the gas price of Ethereum to estimate the transaction fees required to execute certain actions on the Ethereum blockchain within the game, such as transferring assets between players or minting new in-game NFTs. For more on gas limits, see [What is gas limit?](https://ethereum.org/en/developers/docs/gas/#what-is-gas-limit)
 
 ```csharp
 using Web3Unity.Scripts.Library.Ethers.Contracts;

--- a/docs/v2/10_webgl-browser.md
+++ b/docs/v2/10_webgl-browser.md
@@ -39,7 +39,7 @@ int networkId = Web3GL.Network();
 
 ### Block Number {#block-number}
 
-Get the current (i.e. latest) block number.
+Get the current (i.e. latest) block number from a specified node using the `JsonRpcProvider` variable.
 
 ```csharp
 using Web3Unity.Scripts.Library.Ethers.Providers;
@@ -57,7 +57,7 @@ public class WebGLGetBlockNumber : MonoBehaviour
 
 ### Gas Price {#gas-price}
 
-Get the current gas price for a transaction based on chain / network and RPC.
+Get the **current gas price** for a transaction based on chain / network and RPC. Used to estimate the transaction fees required to execute certain actions on the Ethereum blockchain within the game, such as transfering assets between players or minting new in-game NFTs. For more on gas prices, see [What is gas?](https://ethereum.org/en/developers/docs/gas/#what-is-gas)
 
 ```csharp
 using Web3Unity.Scripts.Library.Ethers.Providers;
@@ -75,7 +75,7 @@ public class WebGLGetGasPrice : MonoBehaviour
 
 ### Gas Limit {#gas-limit}
 
-Get the current gas limit for a transaction based on chain / network and RPC.
+Get the **current gas limit** for a transaction based on chain / network and RPC. Used in combination with the gas price of Ethereum to estimate the transaction fees required to execute certain actions on the Ethereum blockchain within the game, such as transfering assets between players or minting new in-game NFTs. For more on gas limits, see [What is gas limit?](https://ethereum.org/en/developers/docs/gas/#what-is-gas-limit)
 
 ```csharp
 using Web3Unity.Scripts.Library.Ethers.Contracts;
@@ -97,6 +97,8 @@ public class WebGLGetGasLimit : MonoBehaviour
 ```
 
 ### Transaction Status {#transaction-status}
+
+Allows the user to send a transaction to a specified Ethereum account using the `Web3GL` library. The transaction includes the recipient address, `value` (in wei), `gasLimit`, and `gasPrice`. Once the transaction is sent, the script checks the status of the transaction by calling the `GetTransactionReceipt` function. If the transaction was successful, the script logs a message indicating success, otherwise it logs a message indicating failure. If an exception is thrown during the transaction process, the script logs the exception.
 
 ```csharp
 using Nethereum.Hex.HexTypes;

--- a/docs/v2/5_erc721-interactions.md
+++ b/docs/v2/5_erc721-interactions.md
@@ -20,7 +20,7 @@ Here's a video explanation to help you better understand our new ERC-721 prefabs
 
 :::info
 
-In the following code snippet examples, we will use an ERC-721 token contract, as found on the Goerli testnet, called "Chain721 (C721)" for demonstration purposes. We use "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2" as the example address to fetch from.
+In the following code snippet examples, we will use an ERC-721 NFT token contract, as found on the Goerli testnet, called "Chain721 (C721)" for demonstration purposes. We use "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2" as the example address to fetch from.
 
 :::
 
@@ -115,7 +115,7 @@ public class ERC721URIExample : MonoBehaviour
 
 ### All 721's {#all-721s"}
 
-Searches through a specified number of `tokenIds` for each NFT contract in the `nftContracts` array, and logs the tokenIds and URIs of the tokens owned by the account.
+Searches through a specified number of `tokenIds` for each contract in the `nftContracts` array, and logs the tokenIds and URIs of the tokens owned by the account.
 
 ```csharp
 using UnityEngine;

--- a/docs/v2/5_erc721-interactions.md
+++ b/docs/v2/5_erc721-interactions.md
@@ -20,13 +20,13 @@ Here's a video explanation to help you better understand our new ERC-721 prefabs
 
 :::info
 
-In the following code snippet examples, we will use an ERC-721 NFT token contract, as found on the Goerli testnet, called "Chain721 (C721)" for demonstration purposes. We use "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2" as the example address to fetch from.
+In the following code snippet examples, we will use an ERC-721 token contract, as found on the Goerli testnet, called "Chain721 (C721)" for demonstration purposes. We use "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2" as the example address to fetch from.
 
 :::
 
 ### Balance Of {#balance-of}
 
-Fetches and counts the balance of a specific ERC-721 NFT token for a specific Ethereum account.
+Fetches and counts the balance of a specific ERC-721 token for a specific Ethereum account.
 
 ```csharp
 using System.Numerics;
@@ -48,7 +48,7 @@ public class ERC721BalanceOfExample : MonoBehaviour
 
 ### Owner Of {#owner-of}
 
-Fetches the owner of a specific ERC-721 NFT token for a specific Ethereum account.
+Fetches the owner of a specific ERC-721 token for a specific Ethereum account.
 
 ```csharp
 using Web3Unity.Scripts.Library.ETHEREUEM.EIP;
@@ -94,7 +94,7 @@ public class ERC721OwnerOfBatchExample : MonoBehaviour
 
 ### URI {#uri"}
 
-Returns the Uniform Resource Identifier (URI) associated with the specified ERC-721 NFT token. The URI may contain metadata about the NFT, such as its name, description, and image.
+Returns the Uniform Resource Identifier (URI) associated with the specified ERC-721 token. The URI may contain metadata about the NFT, such as its name, description, and image.
 
 ```csharp
 using Web3Unity.Scripts.Library.ETHEREUEM.EIP;

--- a/docs/v2/6_erc1155-interactions.md
+++ b/docs/v2/6_erc1155-interactions.md
@@ -22,7 +22,7 @@ Here's a video explanation to help you better understand the new prefabs in web3
 
 :::info
 
- In the following code snippet examples, we will use two separate ERC-1155 NFT token contracts for demonstration purposes. Both can be found on the Goerli testnet, with one collection titled "ERC1155", and the other titled "beautiful collection - 1155".
+ In the following code snippet examples, we will use two separate ERC-1155 token contracts for demonstration purposes. Both can be found on the Goerli testnet, with one collection titled "ERC1155", and the other titled "beautiful collection - 1155".
 :::
 
 ### Balance Of {#balance-of}
@@ -81,7 +81,7 @@ public class ERC1155BalanceOfBatchExample : MonoBehaviour
 
 ### URI {#uri}
 
-Returns the Uniform Resource Identifier (URI) associated with the specified ERC-1155 NFT token. The URI may contain metadata about the NFT, such as its name, description, and image.
+Returns the Uniform Resource Identifier (URI) associated with the specified ERC-1155 token. The URI may contain metadata about the NFT, such as its name, description, and image.
 
 ```csharp
 using Web3Unity.Scripts.Library.ETHEREUEM.EIP;

--- a/docs/v2/7_using-the-minter.md
+++ b/docs/v2/7_using-the-minter.md
@@ -45,4 +45,4 @@ This video shows how to retrieve the balance of a minted asset created with the 
 
 ### Mint NFT Via WebGL & WebWallet Voucher Minting
 
-ChainSafe Gaming's web3.unity SDK provides a voucher minting implementation for minting an NFT via WebGL or WebWallet. Voucher minting can be more secure as it requires additional steps from the user, as opposed to having an open mint function. More information can be found [here](https://docs.gaming.chainsafe.io/v2/minting-with-voucher).
+ChainSafe Gaming's web3.unity SDK provides a voucher minting implementation for minting an NFT via WebGL or WebWallet. Voucher minting can be more secure as it requires additional steps from the user, as opposed to having an open mint function. More information can be found [here](https://docs.gaming.chainsafe.io/current/minting-with-voucher).


### PR DESCRIPTION
Link to the voucher-based minting is a dead link

closes: [#145](https://github.com/ChainSafe/devrel/issues/145)