### PR TITLE
Replaced .BuildAsync() with .LaunchAsync()

### DIFF
--- a/docs/v2.5/11_interacting-with-smart-contracts.md
+++ b/docs/v2.5/11_interacting-with-smart-contracts.md
@@ -53,7 +53,7 @@ var web3 = await new Web3Builder(ProjectConfigUtilities.Load())
             contracts.RegisterContract("shiba", abi, address);
         });
     })
-    .BuildAsync();
+    .LaunchAsync();
 ```
 
 Now you can simply create a new instance of the contract using the contract name:

--- a/docs/v2.5/14_extending-the-sdk.md
+++ b/docs/v2.5/14_extending-the-sdk.md
@@ -73,7 +73,7 @@ var web3 = await new Web3Builder(ProjectConfigUtilities.Load())
     {
         services.UseMyXmlProvider();
     })
-    .BuildAsync();
+    .LaunchAsync();
 ```
 
 Now when you request `Web3.RpcProvider` your new and shiny `IRpcProvider` implementation is returned.
@@ -91,7 +91,7 @@ var web3 = await new Web3Builder(ProjectConfigUtilities.Load())
             { RpcNodeUrl = "letsplayvideogamesallday.org/json-rpc" }
         );
     })
-    .BuildAsync();
+    .LaunchAsync();
 ```
 
 Basically, you just have to create a new class for the configuration data and add a dependency 
@@ -204,7 +204,7 @@ var web3 = await new Web3Builder(ProjectConfigUtilities.Load())
     {
         services.UseNotReallyTrueRandom();
     })
-    .BuildAsync();
+    .LaunchAsync();
 
 var myRandomValue = web3.TrueRandom().GetRandomValue();
 ```

--- a/docs/v2.5/6_configuration.md
+++ b/docs/v2.5/6_configuration.md
@@ -184,7 +184,7 @@ private async void Start()
             services.UseJsonRpcProvider();
             services.UseWebPageWallet();
         })
-        .BuildAsync();
+        .LaunchAsync();
         Web3Acessor.Set(web3);
 }
 ```


### PR DESCRIPTION
We replaced .BuildAsync() with .LaunchAsync() to better reflect what's happening but did not update the docs. This is the update to align the docs with the sdk.